### PR TITLE
Fix: Resolve BindingResolutionException for ProjectVulnerabilityContr…

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Domain\Organizations\Controllers\OrganizationProjectController;
 use App\Domain\Projects\Controllers\ProjectController;
 use App\Domain\Projects\Controllers\ProjectUserController;
 use App\Domain\Projects\Controllers\ProjectTaskController;
+use App\Domain\Projects\Controllers\ProjectVulnerabilityController;
 use App\Domain\Vulnerabilities\Controllers\VulnerabilityTaskController;
 use App\Domain\Tasks\Controllers\TaskController;
 use App\Http\Controllers\DashboardController;


### PR DESCRIPTION
…oller

The ProjectVulnerabilityController class was not being correctly resolved by the router because its namespace was not imported in routes/web.php.

This commit adds the necessary 'use' statement to routes/web.php, ensuring that the existing controller at
app/Domain/Projects/Controllers/ProjectVulnerabilityController.php is correctly found and instantiated when its routes are accessed.

Output: