### PR TITLE
Fix: Correct type_id and category_id fields in vulnerability edit form.

### DIFF
--- a/resources/views/vulnerabilities/edit.blade.php
+++ b/resources/views/vulnerabilities/edit.blade.php
@@ -38,9 +38,28 @@
                         @error('component') <span class="text-red-600 text-sm">{{ $message }}</span> @enderror
                     </div>
                     <div>
-                        <label for="type" class="block font-medium text-gray-700 mb-1">Tipo de vulnerabilidad</label>
-                        <input type="text" name="type" id="type" class="w-full border border-gray-300 rounded px-2 py-1 focus:ring focus:ring-blue-200" value="{{ old('type', $vulnerability->type) }}">
-                        @error('type') <span class="text-red-600 text-sm">{{ $message }}</span> @enderror
+                        <label for="type_id" class="block font-medium text-gray-700 mb-1">Tipo de vulnerabilidad</label>
+                        <select name="type_id" id="type_id" class="w-full border border-gray-300 rounded px-2 py-1 focus:ring focus:ring-blue-200" required>
+                            <option value="">Seleccione un tipo...</option>
+                            @foreach($types as $type)
+                                <option value="{{ $type->id }}" {{ old('type_id', $vulnerability->type_id) == $type->id ? 'selected' : '' }}>
+                                    {{ $type->name }}
+                                </option>
+                            @endforeach
+                        </select>
+                        @error('type_id') <span class="text-red-600 text-sm">{{ $message }}</span> @enderror
+                    </div>
+                    <div>
+                        <label for="category_id" class="block font-medium text-gray-700 mb-1">Categoría de Vulnerabilidad</label>
+                        <select name="category_id" id="category_id" class="w-full border border-gray-300 rounded px-2 py-1 focus:ring focus:ring-blue-200" required>
+                            <option value="">Seleccione una categoría...</option>
+                            @foreach($categories as $category)
+                                <option value="{{ $category->id }}" {{ old('category_id', $vulnerability->category_id) == $category->id ? 'selected' : '' }}>
+                                    {{ $category->name }}
+                                </option>
+                            @endforeach
+                        </select>
+                        @error('category_id') <span class="text-red-600 text-sm">{{ $message }}</span> @enderror
                     </div>
                     <div>
                         <label for="owasp_classification" class="block font-medium text-gray-700 mb-1">Clasificación OWASP</label>


### PR DESCRIPTION
The vulnerability edit form (edit.blade.php) was missing the 'category_id' field and had an incorrect text input for 'type' instead of a select dropdown for 'type_id'.

This commit:
- Replaces the 'type' text input with a 'type_id' select dropdown in `resources/views/vulnerabilities/edit.blade.php`, populated with vulnerability types.
- Adds the missing 'category_id' select dropdown to `resources/views/vulnerabilities/edit.blade.php`, populated with vulnerability categories.

These changes ensure the edit form correctly displays and submits `type_id` and `category_id`, aligning with backend validation and data model expectations.