### PR TITLE
Fix: Correct data mapping in VulnerabilityController for create/update.

### DIFF
--- a/app/Domain/Vulnerabilities/Controllers/VulnerabilityController.php
+++ b/app/Domain/Vulnerabilities/Controllers/VulnerabilityController.php
@@ -172,9 +172,32 @@ class VulnerabilityController extends Controller
         // $validated['assigned_user_id'] = $validated['responsible_id'];
         // unset($validated['responsible_id']);
 
+        $dataForCreate = [
+            'title' => $validated['title'],
+            'detection_date' => $validated['detection_date'] ?? null,
+            'description' => $validated['description'] ?? null,
+            'component' => $validated['component'] ?? null,
+            'project_id' => $validated['project_id'],
+            'type_id' => $validated['type_id'],
+            'assigned_user_id' => $validated['responsible_id'] ?? null,
+            'owasp_classification' => $validated['owasp_classification'] ?? null,
+            'cvss_vector' => $validated['cvss_vector'] ?? null,
+            'cvss_score' => $validated['cvss_score'] ?? null,
+            'severity_level' => $validated['severity'] ?? null,
+            'exploit_probability' => $validated['likelihood'] ?? null,
+            'estimated_impact' => $validated['impact'] ?? null,
+            'category_id' => $validated['category_id'],
+            'resolution_deadline' => $validated['due_date'] ?? null,
+            'priority' => $validated['priority'] ?? null,
+            'detection_source' => $validated['source'] ?? null,
+            'documentation_url' => $validated['documentation_url'] ?? null,
+            // 'state' defaults in DB migration. If explicit set from form is needed:
+            // 'state' => $validated['state'] ?? 'Detectada',
+            'created_by' => Auth::id(), // Corrected from $validated['created_by']
+        ];
 
         // Create the vulnerability record.
-        $vulnerability = Vulnerability::create($validated);
+        $vulnerability = Vulnerability::create($dataForCreate);
 
         // Handle file attachments if provided.
         if ($request->hasFile('attachments')) {
@@ -259,7 +282,7 @@ class VulnerabilityController extends Controller
         // Use validated data from FormRequest or manual validation.
         // $validated = $request->validated(); // Preferred if UpdateVulnerabilityRequest is fully set up.
 
-        // Temporary manual validation to avoid conflicts if 'state' is in UpdateVulnerabilityRequest.
+        // Validation should use form input names
         $validated = $request->validate([
             'title' => 'sometimes|required|string|max:255',
             'description' => 'nullable|string',
@@ -267,27 +290,51 @@ class VulnerabilityController extends Controller
             'project_id' => 'sometimes|required|exists:projects,id',
             'type_id' => 'sometimes|required|exists:vulnerability_types,id',
             'category_id' => 'sometimes|required|exists:vulnerability_categories,id',
-            'responsible_id' => 'nullable|exists:users,id', // Assuming 'responsible_id' maps to 'assigned_user_id'
+            'responsible_id' => 'nullable|exists:users,id', // Form input name
             'owasp_classification' => 'nullable|string|max:255',
             'cvss_vector' => 'nullable|string|max:255',
             'cvss_score' => 'nullable|numeric|min:0|max:10',
-            'severity_level' => 'nullable|string',
-            'exploit_probability' => 'nullable|string',
-            'estimated_impact' => 'nullable|string',
+            'severity' => 'nullable|string', // Form input name
+            'likelihood' => 'nullable|string', // Form input name
+            'impact' => 'nullable|string', // Form input name
             'priority' => 'nullable|string',
-            'detection_source' => 'nullable|string|max:255',
+            'source' => 'nullable|string|max:255', // Form input name
             'documentation_url' => 'nullable|url|max:255',
-            'resolution_deadline' => 'nullable|date',
+            'due_date' => 'nullable|date', // Form input name
             // 'state' should not be updated here; use changeState method.
         ]);
         
-        // Map 'responsible_id' from form to 'assigned_user_id' for the model.
-        if(isset($validated['responsible_id'])) {
-            $validated['assigned_user_id'] = $validated['responsible_id'];
-            unset($validated['responsible_id']);
+        $dataForUpdate = [];
+        foreach ($validated as $key => $value) {
+            if ($key === 'responsible_id') {
+                $dataForUpdate['assigned_user_id'] = $value;
+            } elseif ($key === 'severity') {
+                $dataForUpdate['severity_level'] = $value;
+            } elseif ($key === 'likelihood') {
+                $dataForUpdate['exploit_probability'] = $value;
+            } elseif ($key === 'impact') {
+                $dataForUpdate['estimated_impact'] = $value;
+            } elseif ($key === 'source') {
+                $dataForUpdate['detection_source'] = $value;
+            } elseif ($key === 'due_date') {
+                $dataForUpdate['resolution_deadline'] = $value;
+            } else {
+                // Only add to $dataForUpdate if the key is a valid fillable field
+                // This check is implicitly handled by $vulnerability->update with fillable model property
+                $dataForUpdate[$key] = $value;
+            }
         }
 
-        $vulnerability->update($validated);
+        // Filter out keys not present in $dataForUpdate to avoid issues with $request->validated() if UpdateVulnerabilityRequest is used
+        // For now, this is not strictly needed as $dataForUpdate is built explicitly
+        // $updateData = $request->validated(); // If using FormRequest, this would be the source
+        // if (isset($updateData['responsible_id'])) {
+        //     $updateData['assigned_user_id'] = $updateData['responsible_id'];
+        //     unset($updateData['responsible_id']);
+        // }
+        // ... add other mappings from $updateData to $dataForUpdate if FormRequest validation keys differ from DB ...
+
+        $vulnerability->update($dataForUpdate);
 
         return redirect()->route('vulnerabilities.show', $vulnerability)->with('success', 'Vulnerabilidad actualizada correctamente.');
     }


### PR DESCRIPTION
Resolved an issue where several fields from the vulnerability creation and edit forms were not being saved to the database. This was due to mismatches between form input names (used in validation) and the database column names expected by the Vulnerability model.

This commit implements explicit mapping in the `store` and `update` methods of `VulnerabilityController.php`:
- Form input names like 'responsible_id', 'severity', 'likelihood', 'impact', 'source', and 'due_date' are now correctly mapped to their corresponding database column names ('assigned_user_id', 'severity_level', 'exploit_probability', 'estimated_impact', 'detection_source', 'resolution_deadline') before data is passed to `Vulnerability::create()` or `$vulnerability->update()`.
- Validation rules in the `update` method were also reviewed to ensure consistency with form field names.

All fields submitted through the vulnerability forms should now be correctly saved to the database.