### PR TITLE
Fix: Correct display of fields on vulnerability show page.

### DIFF
--- a/resources/views/vulnerabilities/show.blade.php
+++ b/resources/views/vulnerabilities/show.blade.php
@@ -19,32 +19,32 @@
                     
                         <p class="mb-2"><span class="font-semibold text-gray-700">Estado:</span>
                             <span class="inline-block px-2 py-1 rounded-full text-xs font-semibold
-                                {{ $vulnerability->status === 'Detectada' ? 'bg-yellow-100 text-yellow-700' : '' }}
-                                {{ $vulnerability->status === 'En análisis' ? 'bg-blue-100 text-blue-700' : '' }}
-                                {{ $vulnerability->status === 'En tratamiento' ? 'bg-orange-100 text-orange-700' : '' }}
-                                {{ $vulnerability->status === 'Resuelta' ? 'bg-green-100 text-green-700' : '' }}
-                                {{ $vulnerability->status === 'Cerrada' ? 'bg-gray-200 text-gray-600' : '' }}">
-                                {{ $vulnerability->status }}
+                                {{ $vulnerability->state === 'Detectada' ? 'bg-yellow-100 text-yellow-700' : '' }}
+                                {{ $vulnerability->state === 'En análisis' ? 'bg-blue-100 text-blue-700' : '' }}
+                                {{ $vulnerability->state === 'En tratamiento' ? 'bg-orange-100 text-orange-700' : '' }}
+                                {{ $vulnerability->state === 'Resuelta' ? 'bg-green-100 text-green-700' : '' }}
+                                {{ $vulnerability->state === 'Cerrada' ? 'bg-gray-200 text-gray-600' : '' }}">
+                                {{ $vulnerability->state ?? 'N/A' }}
                             </span>
                         </p>
                         <p class="mb-2"><span class="font-semibold text-gray-700">Proyecto:</span> {{ $vulnerability->project->name ?? '-' }}</p>
-                        <p class="mb-2"><span class="font-semibold text-gray-700">Componente:</span> {{ $vulnerability->component }}</p>
-                        <p class="mb-2"><span class="font-semibold text-gray-700">Tipo:</span> {{ $vulnerability->type }}</p>
-                        <p class="mb-2"><span class="font-semibold text-gray-700">Clasificación OWASP:</span> {{ $vulnerability->owasp_classification }}</p>
-                        <p class="mb-2"><span class="font-semibold text-gray-700">Vector CVSS:</span> {{ $vulnerability->cvss_vector }}</p>
-                        <p class="mb-2"><span class="font-semibold text-gray-700">Puntaje CVSS:</span> {{ $vulnerability->cvss_score }}</p>
-                        <p class="mb-2"><span class="font-semibold text-gray-700">Nivel de severidad:</span> {{ $vulnerability->severity }}</p>
-                        <p class="mb-2"><span class="font-semibold text-gray-700">Probabilidad de explotación:</span> {{ $vulnerability->likelihood }}</p>
-                        <p class="mb-2"><span class="font-semibold text-gray-700">Impacto estimado:</span> {{ $vulnerability->impact }}</p>
-                        <p class="mb-2"><span class="font-semibold text-gray-700">Prioridad:</span> {{ $vulnerability->priority }}</p>
-                        <p class="mb-2"><span class="font-semibold text-gray-700">Fuente de detección:</span> {{ $vulnerability->source }}</p>
-                        <p class="mb-2"><span class="font-semibold text-gray-700">Fecha de detección:</span> {{ $vulnerability->detection_date ? \Carbon\Carbon::parse($vulnerability->detection_date)->format('d/m/Y') : '-' }}</p>
-                        <p class="mb-2"><span class="font-semibold text-gray-700">Fecha límite:</span> {{ $vulnerability->due_date ? \Carbon\Carbon::parse($vulnerability->due_date)->format('d/m/Y') : '-' }}</p>
+                        <p class="mb-2"><span class="font-semibold text-gray-700">Componente:</span> {{ $vulnerability->component ?? 'N/A' }}</p>
+                        <p class="mb-2"><span class="font-semibold text-gray-700">Tipo:</span> {{ $vulnerability->type->name ?? 'N/A' }}</p>
+                        <p class="mb-2"><span class="font-semibold text-gray-700">Clasificación OWASP:</span> {{ $vulnerability->owasp_classification ?? 'N/A' }}</p>
+                        <p class="mb-2"><span class="font-semibold text-gray-700">Vector CVSS:</span> {{ $vulnerability->cvss_vector ?? 'N/A' }}</p>
+                        <p class="mb-2"><span class="font-semibold text-gray-700">Puntaje CVSS:</span> {{ $vulnerability->cvss_score ?? 'N/A' }}</p>
+                        <p class="mb-2"><span class="font-semibold text-gray-700">Nivel de severidad:</span> {{ $vulnerability->severity_level ?? 'N/A' }}</p>
+                        <p class="mb-2"><span class="font-semibold text-gray-700">Probabilidad de explotación:</span> {{ $vulnerability->exploit_probability ?? 'N/A' }}</p>
+                        <p class="mb-2"><span class="font-semibold text-gray-700">Impacto estimado:</span> {{ $vulnerability->estimated_impact ?? 'N/A' }}</p>
+                        <p class="mb-2"><span class="font-semibold text-gray-700">Prioridad:</span> {{ $vulnerability->priority ?? 'N/A' }}</p>
+                        <p class="mb-2"><span class="font-semibold text-gray-700">Fuente de detección:</span> {{ $vulnerability->detection_source ?? 'N/A' }}</p>
+                        <p class="mb-2"><span class="font-semibold text-gray-700">Fecha de detección:</span> {{ $vulnerability->detection_date ? \Carbon\Carbon::parse($vulnerability->detection_date)->format('d/m/Y') : 'N/A' }}</p>
+                        <p class="mb-2"><span class="font-semibold text-gray-700">Fecha límite:</span> {{ $vulnerability->resolution_deadline ? \Carbon\Carbon::parse($vulnerability->resolution_deadline)->format('d/m/Y') : 'N/A' }}</p>
                         <p class="mb-2 col-span-2"><span class="font-semibold text-gray-700">Descripción:</span><br>
-                            <span class="text-gray-700">{{ $vulnerability->description }}</span>
+                            <span class="text-gray-700">{{ $vulnerability->description ?? 'N/A' }}</span>
                         </p>
                         <p class="mb-2 col-span-2"><span class="font-semibold text-gray-700">Observaciones:</span><br>
-                            <span class="text-gray-700">{{ $vulnerability->observations }}</span>
+                            <span class="text-gray-700">{{ $vulnerability->observations ?? 'N/A' }}</span>
                         </p>
                         <p class="mb-2 col-span-2"><span class="font-semibold text-gray-700">Enlace a documentación:</span>
                             @if($vulnerability->documentation_url)


### PR DESCRIPTION
Resolved an issue where several fields on the vulnerability details page (resources/views/vulnerabilities/show.blade.php) were not displaying their values correctly or were showing raw related object data.

This commit updates the Blade template to:
- Use the correct model property names for displaying State (`state` instead of `status`), Severity Level (`severity_level` instead of `severity`), Exploit Probability (`exploit_probability` instead of `likelihood`), Estimated Impact (`estimated_impact` instead of `impact`), Detection Source (`detection_source` instead of `source`), and Resolution Deadline (`resolution_deadline` instead of `due_date`).
- Correctly display the related Vulnerability Type name using `$vulnerability->type->name` instead of outputting the object.
- Add `?? 'N/A'` as a fallback for these and other fields to gracefully handle null values.

All saved vulnerability data should now be accurately displayed on the show page.