### PR TITLE
Fix: Scope available users by organization in ProjectUserController@c…

### DIFF
--- a/app/Domain/Projects/Controllers/ProjectUserController.php
+++ b/app/Domain/Projects/Controllers/ProjectUserController.php
@@ -50,10 +50,15 @@ class ProjectUserController extends Controller
         // 'asignarUsuarios' should be a defined ability in ProjectPolicy.
         $this->authorize('asignarUsuarios', $project);
 
-        // Fetch users who are not already part of this project.
-        $availableUsers = User::whereDoesntHave('projects', function ($query) use ($project) {
-            $query->where('project_id', $project->id);
-        })->orderBy('name')->get();
+        $organizationId = $project->organization_id;
+
+        // Fetch users from the same organization who are not already part of this project.
+        $availableUsers = User::where('organization_id', $organizationId)
+            ->whereDoesntHave('projects', function ($query) use ($project) {
+                $query->where('projects.id', $project->id); // Check against the id column of the projects table
+            })
+            ->orderBy('name')
+            ->get();
 
         return view('projects.users.create', [
             'project' => $project,


### PR DESCRIPTION
…reate.

Resolved an issue where the 'Add Users to Project' interface (ProjectUserController@create) listed all system users instead of only users from the project's parent organization.

This commit modifies the Eloquent query in the `create` method of `app/Domain/Projects/Controllers/ProjectUserController.php` to include a condition that filters users by `$project->organization_id`.

Now, when adding users to a project, the list of available users will only include those belonging to the same organization as the project and who are not already members of that project.