### PR TITLE
Fix: Correct validation and data mapping in ProjectVulnerabilityContr…

### DIFF
--- a/app/Domain/Projects/Controllers/ProjectVulnerabilityController.php
+++ b/app/Domain/Projects/Controllers/ProjectVulnerabilityController.php
@@ -66,45 +66,71 @@ class ProjectVulnerabilityController extends Controller
 
         $validated = $request->validate([
             'title' => 'required|string|max:255',
-            'detection_date' => 'required|date',
-            'type' => 'required|string|max:255',
-            'description' => 'required|string',
-            'component' => 'required|string|max:255',
-            'owasp_classification' => 'required|string|max:255',
-            'cvss_vector' => 'required|string|max:255',
-            'cvss_score' => 'required|numeric|min:0|max:10',
-            'severity' => 'required|string|in:Baja,Media,Alta,Crítica',
-            'likelihood' => 'required|string|max:255',
-            'impact' => 'required|string|max:255',
-            'due_date' => 'required|date',
-            'priority' => 'required|string|in:Baja,Media,Alta,Crítica',
-            'source' => 'required|string|max:255',
+            'detection_date' => 'nullable|date',
+            'description' => 'nullable|string',
+            'component' => 'nullable|string|max:255',
+            'type_id' => 'required|exists:vulnerability_types,id',
+            'responsible_id' => 'nullable|exists:users,id', // Changed to nullable as per VulnerabilityController
+            'category_id' => 'required|exists:vulnerability_categories,id',
+            'owasp_classification' => 'nullable|string|max:255',
+            'cvss_vector' => 'nullable|string|max:255',
+            'cvss_score' => 'nullable|numeric|min:0|max:10',
+            'severity' => 'nullable|string|in:Baja,Media,Alta,Crítica',
+            'likelihood' => 'nullable|numeric',
+            'impact' => 'nullable|string|in:Alto,Bajo',
+            'due_date' => 'nullable|date',
+            'priority' => 'nullable|string|in:Baja,Media,Alta,Crítica',
+            'source' => 'nullable|string|max:255',
             'documentation_url' => 'nullable|url|max:255',
-            'attachments.*' => 'nullable|file|max:10240', // cada archivo máx 10MB
+            'attachments.*' => 'nullable|file|max:10240',
             'observations' => 'nullable|string',
         ]);
 
-        $vulnerability = $project->vulnerabilities()->create([
+        $dataForCreate = [
             'title' => $validated['title'],
+            'detection_date' => $validated['detection_date'] ?? null,
             'description' => $validated['description'] ?? null,
-            'category_id' => 1,
+            'component' => $validated['component'] ?? null,
+            'project_id' => $project->id, // Implicitly from the route model binding
+            'type_id' => $validated['type_id'],
+            'assigned_user_id' => $validated['responsible_id'] ?? null,
+            'owasp_classification' => $validated['owasp_classification'] ?? null,
+            'cvss_vector' => $validated['cvss_vector'] ?? null,
+            'cvss_score' => $validated['cvss_score'] ?? null,
+            'severity_level' => $validated['severity'] ?? null,
+            'exploit_probability' => $validated['likelihood'] ?? null,
+            'estimated_impact' => $validated['impact'] ?? null,
+            'category_id' => $validated['category_id'],
+            'resolution_deadline' => $validated['due_date'] ?? null,
+            'priority' => $validated['priority'] ?? null,
+            'detection_source' => $validated['source'] ?? null,
+            'documentation_url' => $validated['documentation_url'] ?? null,
+            // 'observations' is not directly a DB field, handle as comment if needed after creation
             'created_by' => Auth::id(),
-            'type' => $validated['type'],
-            'severity_level' => $validated['severity'],
-            'component' => $validated['component'],
-            'cvss_score' => $validated['cvss_score'],
-            'cvss_vector' => $validated['cvss_vector'],
-            'likelihood' => $validated['likelihood'],
-            'impact' => $validated['impact'],
-            'detection_date' => $validated['detection_date'],
-            'resolution_deadline' => $validated['due_date'],
-            'documentation_url' => $validated['documentation_url'],
-            'detection_source' => $validated['source'],
-            'priority' => $validated['priority'],
-            'project_id' => $project->id,
-            'owasp_classification' => $validated['owasp_classification'],
-            'observations' => $validated['observations'],
-        ]);
+            // 'state' defaults in DB migration.
+        ];
+
+        $vulnerability = $project->vulnerabilities()->create($dataForCreate);
+
+        // Handle observations as a comment, if provided
+        if (!empty($validated['observations'])) {
+            $vulnerability->comments()->create([
+                'comment' => $validated['observations'],
+                'user_id' => Auth::id(),
+            ]);
+        }
+
+        // Handle file attachments (code from VulnerabilityController, needs Vulnerability model instance)
+        if ($request->hasFile('attachments')) {
+            foreach ($request->file('attachments') as $file) {
+                $path = $file->store('vulnerabilities/attachments', 'public');
+                $vulnerability->files()->create([ // Assumes Vulnerability model has files() relationship
+                    'path' => $path,
+                    'original_name' => $file->getClientOriginalName(),
+                    'uploaded_by' => Auth::id(),
+                ]);
+            }
+        }
 
 
         return redirect()


### PR DESCRIPTION
…oller.

Resolved issues in `ProjectVulnerabilityController@store` where form data for creating vulnerabilities was not being correctly validated or saved due to mismatched field names and validation rules.

This commit includes:
- Updated validation rules in `ProjectVulnerabilityController@store` to accurately reflect form fields from `vulnerabilities.create.blade.php`, including proper validation for `type_id`, `category_id`, `responsible_id`, `likelihood`, `impact`, and making other fields appropriately nullable.
- Implemented explicit data mapping in the `store` method to translate validated form field names (e.g., 'responsible_id', 'severity') to their corresponding database column/model attribute names (e.g., 'assigned_user_id', 'severity_level') before creating the Vulnerability record.
- Removed hardcoded `category_id` and ensured it's sourced from the form.
- Added handling for 'observations' (as comments) and 'attachments' to align with `VulnerabilityController` functionality.

Creating vulnerabilities via `ProjectVulnerabilityController` should now correctly validate and save all submitted data.