### PR TITLE
Refactor: Restrict inactive projects & closed vulnerabilities, update…

### DIFF
--- a/resources/views/projects/index.blade.php
+++ b/resources/views/projects/index.blade.php
@@ -73,10 +73,12 @@
                                             <div x-show="open" @click.away="open = false"
                                                  class="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 z-50">
                                                 
+                                                @can('verVulnerabilidades', $project)
                                                 <a href="{{ route('projects.vulnerabilities.index', $project) }}" 
                                                    class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
                                                     Ver Vulnerabilidades
                                                 </a>
+                                                @endcan
                                                 <a href="{{ route('projects.users.index', $project) }}" 
                                                    class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
                                                     Gestionar Usuarios

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -88,7 +88,9 @@
                             <p class="text-sm text-gray-500">No hay vulnerabilidades registradas para este proyecto.</p>
                         @endif
                         <div class="mt-4">
+                             @can('verVulnerabilidades', $project)
                              <a href="{{ route('projects.vulnerabilities.index', $project) }}" class="text-sm text-blue-600 hover:underline">Ver Todas las Vulnerabilidades del Proyecto</a>
+                             @endcan
                         </div>
                     </div>
 

--- a/resources/views/vulnerabilities/index.blade.php
+++ b/resources/views/vulnerabilities/index.blade.php
@@ -97,6 +97,7 @@
                                                 </div>
                                             </a>
 
+                                            @can('update', $vulnerability)
                                             <a href="{{ route('vulnerabilities.edit', $vulnerability) }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
                                                 <div class="flex items-center">
                                                     <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
@@ -105,7 +106,9 @@
                                                     Editar
                                                 </div>
                                             </a>
+                                            @endcan
 
+                                            @can('assignUser', $vulnerability)
                                             <a href="{{ route('vulnerabilities.users.index', $vulnerability) }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
                                                 <div class="flex items-center">
                                                     <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
@@ -114,7 +117,9 @@
                                                     Usuarios Asignados
                                                 </div>
                                             </a>
+                                            @endcan
 
+                                            @can('crearTareas', $vulnerability)
                                             <!-- tareas -->
                                             <a href="{{ route('vulnerabilities.tasks.index', $vulnerability) }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
                                                 <div class="flex items-center">
@@ -124,7 +129,9 @@
                                                     Tareas
                                                 </div>
                                             </a>
+                                            @endcan
 
+                                            @can('delete', $vulnerability)
                                             <form action="{{ route('vulnerabilities.destroy', $vulnerability) }}" method="POST" class="block">
                                                 @csrf
                                                 @method('DELETE')
@@ -139,6 +146,7 @@
                                                     </div>
                                                 </button>
                                             </form>
+                                            @endcan
                                         </div>
                                     </div>
                                 </td>

--- a/resources/views/vulnerabilities/show.blade.php
+++ b/resources/views/vulnerabilities/show.blade.php
@@ -55,6 +55,7 @@
                         </p>
                 </div>
 
+                @can('changeStatus', $vulnerability)
                 {{-- Sección para Cambiar Estado --}}
                 @if ($vulnerability->state !== App\Domain\Vulnerabilities\Models\Vulnerability::STATE_CERRADA || 
                      (isset(App\Domain\Vulnerabilities\Models\Vulnerability::$stateTransitions[App\Domain\Vulnerabilities\Models\Vulnerability::STATE_CERRADA]) && 
@@ -93,6 +94,7 @@
                          <p class="text-gray-600">La vulnerabilidad está cerrada y no se puede cambiar su estado (a menos que se defina una reapertura específica).</p>
                     </div>
                 @endif
+                @endcan
 
 
                 {{-- Sección para Añadir Comentarios (simplificada) --}}
@@ -184,6 +186,7 @@
                         ← Volver al listado
                     </a>
                     <div class="flex gap-2">
+                        @can('assignUser', $vulnerability)
                         <a href="{{ route('vulnerabilities.users.index', $vulnerability) }}"
                             class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded shadow transition inline-flex items-center">
                             <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -191,11 +194,14 @@
                             </svg>
                             Gestionar Usuarios
                         </a>
+                        @endcan
+                        @can('update', $vulnerability)
                         <a href="{{ route('vulnerabilities.edit', $vulnerability) }}"
                             class="bg-yellow-500 hover:bg-yellow-600 text-white px-6 py-2 rounded shadow transition">
                             Editar
                         </a>
-                        @can('create', [App\Domain\Tasks\Models\Task::class, $vulnerability])
+                        @endcan
+                        @can('crearTareas', $vulnerability)
                             <a href="{{ route('vulnerabilities.tasks.create', $vulnerability) }}" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded shadow transition inline-flex items-center">
                                 <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m-3-3v6m5 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
                                 Añadir Tarea


### PR DESCRIPTION
… UI.

This commit introduces authorization restrictions based on project and vulnerability statuses, and updates the UI to reflect these rules.

Backend Changes:
1.  **Inactive Projects:**
    *   You cannot manage (create, view, etc.) vulnerabilities
        associated with inactive projects.
    *   Enforced in `ProjectPolicy`, `VulnerabilityPolicy`, and `TaskPolicy`.

2.  **Closed Vulnerabilities:**
    *   You cannot manage (update, delete, change status, assign users,
        create tasks for) vulnerabilities marked as 'Cerrada' (Closed).
    *   Enforced in `VulnerabilityPolicy` and `TaskPolicy`.

3.  **Task Management:**
    *   Task creation, update, and deletion are restricted if the
        associated project is inactive or the associated vulnerability is closed.
    *   `TaskPolicy@create` was made more flexible to handle different
        authorization contexts.

4.  **Testing:**
    *   Added feature tests (`ProjectPolicyTest.php`,
        `VulnerabilityPolicyTest.php`, `TaskPolicyTest.php`) for new
        authorization rules.

UI Changes:
*   Management options (buttons/links for edit, delete, create task, etc.)
    in Blade views for Projects, Vulnerabilities, and Tasks are now
    conditionally rendered using `@can` directives. This ensures that
    you are not shown actions you are not authorized to perform,
    improving your experience by preventing unnecessary 403 error pages.
    Affected views include:
    *   `resources/views/vulnerabilities/index.blade.php`
    *   `resources/views/vulnerabilities/show.blade.php`
    *   `resources/views/projects/index.blade.php`
    *   `resources/views/projects/show.blade.php`
    *   (Task views were confirmed to already have appropriate `@can` directives)

These changes ensure the system adheres to business rules regarding the management of entities in non-active or terminal states, both in the backend logic and frontend presentation.