### PR TITLE
Refactor: Allow viewing vulnerabilities of inactive projects, restric…

### DIFF
--- a/app/Domain/Projects/Policies/ProjectPolicy.php
+++ b/app/Domain/Projects/Policies/ProjectPolicy.php
@@ -106,11 +106,6 @@ class ProjectPolicy
         if (!$user->hasPermissionTo('ver vulnerabilidades')) {
             return false;
         }
-
-        // Verifica si el proyecto está activo
-        if ($project->status !== 'active') {
-            return false;
-        }
         
         // Admin y líderes pueden ver todas las vulnerabilidades de cualquier proyecto
         if ($user->hasRole(['admin', 'lider'])) {

--- a/resources/views/vulnerabilities/index.blade.php
+++ b/resources/views/vulnerabilities/index.blade.php
@@ -10,14 +10,25 @@
                         @endif
                     </div>
                     <div class="flex gap-2">
-                        @can('create', App\Domain\Vulnerabilities\Models\Vulnerability::class)
-                        <a href="{{ $viewModel->createRoute }}" class="bg-blue-600 text-white px-4 py-2 rounded shadow hover:bg-blue-700 transition inline-flex items-center">
-                            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
-                            </svg>
-                            Nueva Vulnerabilidad
-                        </a>
-                        @endcan
+                        @if(isset($viewModel->project) && $viewModel->context === 'project')
+                            @can('crearVulnerabilidades', $viewModel->project)
+                            <a href="{{ $viewModel->createRoute }}" class="bg-blue-600 text-white px-4 py-2 rounded shadow hover:bg-blue-700 transition inline-flex items-center">
+                                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+                                </svg>
+                                Nueva Vulnerabilidad
+                            </a>
+                            @endcan
+                        @else
+                            @can('create', App\Domain\Vulnerabilities\Models\Vulnerability::class)
+                            <a href="{{ $viewModel->createRoute }}" class="bg-blue-600 text-white px-4 py-2 rounded shadow hover:bg-blue-700 transition inline-flex items-center">
+                                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+                                </svg>
+                                Nueva Vulnerabilidad
+                            </a>
+                            @endcan
+                        @endif
                         @if($viewModel->can_import)
                         <a href="{{ route('vulnerabilities.charge') }}" class="bg-green-600 text-white px-4 py-2 rounded shadow hover:bg-green-700 transition inline-flex items-center">
                             <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">

--- a/tests/Feature/ProjectPolicyTest.php
+++ b/tests/Feature/ProjectPolicyTest.php
@@ -84,10 +84,9 @@ class ProjectPolicyTest extends TestCase
     }
 
     /** @test */
-    public function lider_cannot_view_vulnerabilities_of_inactive_project()
+    public function lider_can_view_vulnerabilities_of_inactive_project() // RENAMED and behaviour changed
     {
-        // Assuming the 'verVulnerabilidades' policy method in ProjectPolicy was updated
-        // to check project status.
+        // Policy for verVulnerabilidades no longer checks project status.
         // And assuming there's a route like projects.vulnerabilities.index
 
         // Create a vulnerability in the inactive project to test against
@@ -95,17 +94,19 @@ class ProjectPolicyTest extends TestCase
 
         $this->actingAs($this->liderUser)
             ->getJson(route('projects.vulnerabilities.index', $this->inactiveProject))
-            ->assertStatus(403);
+            ->assertStatus(200); // CHANGED from 403 to 200
     }
 
     /** @test */
-    public function miembro_cannot_view_vulnerabilities_of_inactive_project()
+    public function miembro_can_view_vulnerabilities_of_inactive_project_they_are_member_of() // RENAMED (slightly for clarity) and behaviour changed
     {
+        // Policy for verVulnerabilidades no longer checks project status.
+        // Miembro should be able to see vulnerabilities if they are part of the project.
         Vulnerability::factory()->create(['project_id' => $this->inactiveProject->id]);
 
-        $this->actingAs($this->miembroUser)
+        $this->actingAs($this->miembroUser) // User is attached to inactiveProject in setUp()
             ->getJson(route('projects.vulnerabilities.index', $this->inactiveProject))
-            ->assertStatus(403);
+            ->assertStatus(200); // CHANGED from 403 to 200
     }
 
     /** @test */


### PR DESCRIPTION
…t actions.

This commit refines the handling of inactive projects based on new feedback:

1.  **Policy Adjustments:**
    *   `ProjectPolicy@verVulnerabilidades` now allows users with appropriate
        permissions to view the list of vulnerabilities associated with an
        inactive project. The previous restriction based on project status
        for viewing has been removed.
    *   `ProjectPolicy@crearVulnerabilidades` still correctly prevents
        creating new vulnerabilities for inactive projects.
    *   `VulnerabilityPolicy` and `TaskPolicy` methods (for update, delete,
        create tasks, etc.) continue to prevent actions if the parent
        project is inactive or the vulnerability is closed.

2.  **Testing Updates:**
    *   Tests in `ProjectPolicyTest.php` were updated to assert that users
        (e.g., 'lider', 'miembro') *can* now view vulnerabilities of
        inactive projects.
    *   Tests still ensure that creating vulnerabilities for inactive
        projects is forbidden.

3.  **Blade View Adjustments:**
    *   Links to "Ver Vulnerabilidades" on project pages will now be shown
        for inactive projects (if you have permission), due to the
        `ProjectPolicy@verVulnerabilidades` change.
    *   The "Create Vulnerability" button on the `vulnerabilities.index.blade.php`
        page, when viewed in the context of a specific project, is now
        conditionally rendered using `@can('crearVulnerabilidades', $project)`.
        This ensures it's hidden if the project is inactive.
    *   Other UI elements for managing existing vulnerabilities or tasks
        (edit, delete, etc.) remain hidden if the project is inactive or
        the vulnerability is closed, as per previous UI updates and
        underlying policies.

This change ensures that you can access historical vulnerability data for inactive projects (read-only) while preventing any modifications or additions, aligning with the specified requirements.