### PR TITLE
Fix(db): Correct project seeding by removing direct lider_id assignment.

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -167,7 +167,7 @@ class DatabaseSeeder extends Seeder
                     'identifier' => 'ORG1-PAD',
                     'general_objective' => 'Proyecto activo para dashboard de líder y miembro.',
                     'status' => 'active',
-                    'lider_id' => $leaderUser->id,
+                    // 'lider_id' => $leaderUser->id, // Removed direct lider_id assignment
                     'created_by' => $adminUser->id,
                 ]
             );
@@ -183,7 +183,7 @@ class DatabaseSeeder extends Seeder
                     'identifier' => 'ORG1-PID',
                     'general_objective' => 'Proyecto inactivo para dashboard de líder y miembro.',
                     'status' => 'inactive',
-                    'lider_id' => $leaderUser->id,
+                    // 'lider_id' => $leaderUser->id, // Removed direct lider_id assignment
                     'created_by' => $adminUser->id,
                 ]
             );


### PR DESCRIPTION
Removes the attempt to set a `lider_id` column directly when creating specific projects ("Proyecto Activo (Dashboard)", "Proyecto Inactivo (Dashboard)") in `DatabaseSeeder.php`. The `projects` table does not have a `lider_id` column; leader association is managed through the `project_user` pivot table.

The seeder already correctly attaches the leader user to these projects via the `users()` relationship (pivot table). This change resolves the `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'lider_id'` error encountered during `migrate:fresh --seed`.