### PR TITLE
I've corrected the project seeding by removing the `created_by` field.

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -168,7 +168,7 @@ class DatabaseSeeder extends Seeder
                     'general_objective' => 'Proyecto activo para dashboard de líder y miembro.',
                     'status' => 'active',
                     // 'lider_id' => $leaderUser->id, // Removed direct lider_id assignment
-                    'created_by' => $adminUser->id,
+                    // 'created_by' => $adminUser->id, // Removed created_by assignment
                 ]
             );
             $project1_org1->users()->syncWithoutDetaching([$leaderUser->id, $memberUser->id]);
@@ -184,7 +184,7 @@ class DatabaseSeeder extends Seeder
                     'general_objective' => 'Proyecto inactivo para dashboard de líder y miembro.',
                     'status' => 'inactive',
                     // 'lider_id' => $leaderUser->id, // Removed direct lider_id assignment
-                    'created_by' => $adminUser->id,
+                    // 'created_by' => $adminUser->id, // Removed created_by assignment
                 ]
             );
             $project2_org1->users()->syncWithoutDetaching([$leaderUser->id, $memberUser->id]);


### PR DESCRIPTION
I removed the attempt to set a `created_by` field when creating specific projects ("Proyecto Activo (Dashboard)", "Proyecto Inactivo (Dashboard)") in `DatabaseSeeder.php`. The `projects` table does not have this column.

This change resolves the SQLSTATE[42S22] error: "Column not found: 1054 Unknown column 'created_by' in 'field list'" encountered during database migration and seeding. Vulnerabilities have a `created_by` field, but projects do not in the current schema.