### PR TITLE
Fix(db): Add missing Task model import in DatabaseSeeder.

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\User;
 use App\Domain\Organizations\Models\Organization;
+use App\Domain\Tasks\Models\Task; // Added Task model import
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Database\Seeder;


### PR DESCRIPTION
Adds the `use App\Domain\Tasks\Models\Task;` statement to `database/seeders/DatabaseSeeder.php`.

This resolves the "Error: Class 'Database\Seeders\Task' not found" that occurred during `php artisan migrate:fresh --seed` when the seeder attempted to create Task records without the model being properly imported.