### PR TITLE
Fix(db): Modify vulnerability columns for encrypted data.

### DIFF
--- a/database/migrations/2023_10_27_000000_modify_encrypted_fields_in_vulnerabilities_table.php
+++ b/database/migrations/2023_10_27_000000_modify_encrypted_fields_in_vulnerabilities_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('vulnerabilities', function (Blueprint $table) {
+            // Change columns to TEXT type to accommodate potentially longer encrypted strings
+            $table->text('title')->change();
+            $table->text('description')->nullable()->change();
+            $table->text('component')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('vulnerabilities', function (Blueprint $table) {
+            // Reverting to VARCHAR(255). This might cause data truncation if the
+            // data stored in TEXT format (especially if encrypted) was longer than 255 characters.
+            // This is a simplification; a real rollback might need more sophisticated data handling
+            // or accept that the rollback is destructive for oversized data.
+            $table->string('title', 255)->change();
+            $table->string('description', 255)->nullable()->change();
+            $table->string('component', 255)->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
Creates a new migration to alter the `vulnerabilities` table. The `title`, `description`, and `component` columns are changed to the `TEXT` data type.

This change is necessary because these fields are defined as 'encrypted' in the `Vulnerability` model's casts. Encrypted strings are often significantly longer than their plain text counterparts and can exceed default VARCHAR(255) limits.

Changing these columns to TEXT prevents "SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column" errors during seeding or normal application operation when these encrypted fields are saved.