### PR TITLE
Fix(dashboard): Correct project count logic in LiderDashboardService.

### DIFF
--- a/app/Domain/Dashboard/Services/LiderDashboardService.php
+++ b/app/Domain/Dashboard/Services/LiderDashboardService.php
@@ -19,9 +19,9 @@ class LiderDashboardService
         if (method_exists($user, 'projectsLed')) { // Example: if there's a specific relationship for projects led
             $projectsLedCount = $user->projectsLed()->count();
         } elseif (method_exists($user, 'projects')) { // Fallback to a general projects relationship
-             // This might need refinement based on how 'lider' association is defined.
-             // If 'lider' means they are the 'lider_id' on projects table:
-             $projectsLedCount = \App\Domain\Projects\Models\Project::where('lider_id', $user->id)->count();
+             // This assumes User->projects() correctly fetches projects this leader is associated with
+             // via the project_user pivot table.
+             $projectsLedCount = $user->projects()->count();
         }
 
         $data = [


### PR DESCRIPTION
Modifies `LiderDashboardService.php` to correctly count projects associated with a 'Líder' user. Previously, it was attempting to query a non-existent `lider_id` column on the `projects` table.

The service now uses the `$user->projects()->count()` Eloquent relationship method, which relies on the `project_user` pivot table to determine project associations. This aligns with the database schema and recent seeder updates.

This change resolves the "SQLSTATE[42S22]: Column not found: 1054 Unknown column 'lider_id' in 'where clause'" error encountered when a 'Líder' user accessed the dashboard.