### PR TITLE
feat: Add last_login_at to track user activity

### DIFF
--- a/app/Listeners/LogSuccessfulLogin.php
+++ b/app/Listeners/LogSuccessfulLogin.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Auth\Events\Authenticated;
+use Illuminate\Support\Facades\Auth;
+
+class LogSuccessfulLogin
+{
+    /**
+     * Handle the event.
+     *
+     * @param  \Illuminate\Auth\Events\Authenticated  $event
+     * @return void
+     */
+    public function handle(Authenticated $event): void
+    {
+        if (Auth::check()) {
+            Auth::user()->update(['last_login_at' => now()]);
+        }
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -73,6 +73,7 @@ class User extends Authenticatable
         'identification', // User's identification number (e.g., national ID, employee ID)
         'area',           // Functional area or department of the user
         'organization_id', // ID of the organization the user belongs to
+        'last_login_at',
     ];
 
     /**
@@ -108,6 +109,7 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed', // Automatically hashes passwords when set
             'identification' => 'encrypted', // Encrypts the identification field
+            'last_login_at' => 'datetime',
         ];
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,6 +11,8 @@ use Illuminate\Database\Eloquent\Events\PivotAttached;
 use Illuminate\Database\Eloquent\Events\PivotDetached;
 use App\Listeners\HandlePivotAttached;
 use App\Listeners\HandlePivotDetached;
+use Illuminate\Auth\Events\Authenticated;
+use App\Listeners\LogSuccessfulLogin;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -30,5 +32,9 @@ class AppServiceProvider extends ServiceProvider
         Vulnerability::observe(VulnerabilityObserver::class); // Añadido
         Event::listen(PivotAttached::class, [HandlePivotAttached::class, 'handle']);
         Event::listen(PivotDetached::class, [HandlePivotDetached::class, 'handle']);
+        Event::listen(
+            Authenticated::class,
+            [LogSuccessfulLogin::class, 'handle']
+        );
     }
 }

--- a/database/migrations/2025_06_02_025717_add_last_login_at_to_users_table.php
+++ b/database/migrations/2025_06_02_025717_add_last_login_at_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('last_login_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/tests/Feature/UserLoginEventTest.php
+++ b/tests/Feature/UserLoginEventTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Auth\Events\Authenticated;
+
+class UserLoginEventTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test that the last_login_at timestamp is updated when a user logs in.
+     *
+     * @return void
+     */
+    public function test_last_login_at_is_updated_on_login(): void
+    {
+        // Create a user
+        $user = User::factory()->create();
+
+        // Assert that last_login_at is initially null
+        $this->assertNull($user->last_login_at);
+
+        // Simulate login by firing the Authenticated event
+        Event::dispatch(new Authenticated('web', $user));
+
+        // Refresh the user model from the database
+        $user->refresh();
+
+        // Assert that last_login_at is now set
+        $this->assertNotNull($user->last_login_at);
+
+        // Assert that the timestamp is recent (within 5 seconds of now)
+        $this->assertTrue($user->last_login_at->diffInSeconds(now()) < 5);
+    }
+}

--- a/tests/Unit/AdminDashboardServiceTest.php
+++ b/tests/Unit/AdminDashboardServiceTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Models\User;
+use App\Services\AdminDashboardService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Carbon\Carbon;
+
+class AdminDashboardServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test the inactive_users_count method of AdminDashboardService.
+     *
+     * @return void
+     */
+    public function test_inactive_users_count(): void
+    {
+        // Create a user who logged in less than 30 days ago
+        User::factory()->create(['last_login_at' => Carbon::now()->subDays(10)]);
+
+        // Create a user who logged in more than 30 days ago
+        User::factory()->create(['last_login_at' => Carbon::now()->subDays(40)]);
+
+        // Create a user who has never logged in
+        User::factory()->create(['last_login_at' => null]);
+
+        // Create another user who also logged in more than 30 days ago
+        User::factory()->create(['last_login_at' => Carbon::now()->subDays(50)]);
+
+        // Instantiate the AdminDashboardService
+        $service = new AdminDashboardService();
+
+        // Call the getData() method
+        $data = $service->getData();
+
+        // Assert that the inactive_users_count in the result is 2
+        // (Users who logged in more than 30 days ago OR never logged in)
+        $this->assertEquals(2, $data['inactive_users_count']);
+    }
+}


### PR DESCRIPTION
This commit introduces a `last_login_at` timestamp to the `users` table to track when you last logged in.

Key changes:
- Added a database migration to create the `last_login_at` nullable timestamp column on the `users` table.
- Updated the `User` model to include `last_login_at` in fillable attributes and casts.
- Implemented an event listener for the `Authenticated` event to update your `last_login_at` timestamp upon successful login. The listener is registered in `AppServiceProvider` due to the absence of `EventServiceProvider`.
- The `AdminDashboardService` now correctly calculates `inactive_users_count` using the new `last_login_at` field. This counts users who have logged in previously, but not within the last 30 days.
- Added feature and unit tests to verify:
    - `last_login_at` is updated correctly upon login.
    - `inactive_users_count` in `AdminDashboardService` correctly identifies users based on the `last_login_at` data.

This resolves the issue where queries for `last_login_at` would fail due to the column not existing.