### PR TITLE
Fix: Prevent error in LogSuccessfulLogin listener

### DIFF
--- a/app/Listeners/LogSuccessfulLogin.php
+++ b/app/Listeners/LogSuccessfulLogin.php
@@ -16,7 +16,11 @@ class LogSuccessfulLogin
     public function handle(Authenticated $event): void
     {
         if (Auth::check()) {
-            Auth::user()->update(['last_login_at' => now()]);
+            // Attempted to update 'last_login_at' here, but the column was not found on the 'users' table.
+            // This line has been removed to prevent errors.
+            // If tracking the last login time on the User model is still required,
+            // please ensure the 'last_login_at' timestamp column exists on the 'users' table
+            // (e.g., by adding it via a new database migration).
         }
     }
 }


### PR DESCRIPTION
The LogSuccessfulLogin listener was attempting to update a 'last_login_at' column on the 'users' table which does not exist, causing an 'SQLSTATE[42S22]: Column not found' error.

This commit removes the offending line `Auth::user()->update(['last_login_at' => now()]);` from `app/Listeners/LogSuccessfulLogin.php`.

An explanatory comment has been added in its place, suggesting that if you still require the functionality of tracking the last login time on the User model, the 'last_login_at' column should be (re-)added
to the 'users' table via a new database migration.