### PR TITLE
Fix: Prevent error in AdminDashboardService due to missing column

### DIFF
--- a/app/Domain/Dashboard/Services/AdminDashboardService.php
+++ b/app/Domain/Dashboard/Services/AdminDashboardService.php
@@ -26,9 +26,7 @@ class AdminDashboardService
                 ->whereNotIn('state', ['Resuelta', 'Cerrada'])
                 ->count(),
             'sla_compliance_percentage' => -1, // Placeholder: Specific SLA logic needed
-            // Assuming User model has last_login_at. If not, this will throw an error.
-            // Add a check or use a different approach if last_login_at is not guaranteed.
-            'inactive_users_count' => User::where('last_login_at', '<', now()->subDays(30))->count(),
+            'inactive_users_count' => 0, // Feature disabled: 'last_login_at' column missing from 'users' table. To enable, (re-)add column via migration.
             // 'avg_resolution_time_per_org' will be fetched via a separate API call
         ];
 


### PR DESCRIPTION
The AdminDashboardService was attempting to query the 'last_login_at' column on the 'users' table to calculate 'inactive_users_count'. This column does not exist, leading to an 'SQLSTATE[42S22]: Column not found' error.

This commit modifies `app/Domain/Dashboard/Services/AdminDashboardService.php` to address this:
- The calculation for 'inactive_users_count' is replaced with a default value of 0.
- A comment is added to explain that this feature is temporarily disabled due to the missing 'last_login_at' column and advises that the column should be (re-)added via a database migration if this functionality is required.
- Redundant preceding comments related to the missing column were removed.

This change ensures the dashboard service does not error out and maintains data structure consistency for the dashboard.