### PR TITLE
Fix: Resolve integrity constraint violation for audit logs

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -55,8 +55,8 @@ class DashboardController extends Controller
                 'user_id' => $user->id,
                 'action' => 'view_dashboard',
                 'description' => "User viewed {$dashboard_type} dashboard.",
-                'auditable_type' => 'Dashboard',
-                'auditable_id' => null,
+                'auditable_type' => \App\Models\User::class,
+                'auditable_id' => $user->id,
             ]);
         }
 


### PR DESCRIPTION
The DashboardController was creating audit log entries for dashboard views with `auditable_type` as 'Dashboard' and `auditable_id` as null. This caused an 'SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'auditable_id' cannot be null' error because the `audit_logs` table schema requires `auditable_id` to be non-null.

This commit updates `app/Http/Controllers/DashboardController.php` to correctly populate these fields:
- `auditable_type` is now set to `\App\Models\User::class`.
- `auditable_id` is now set to the ID of the authenticated user (`$user->id`).

This change ensures that dashboard view audit logs are valid and correctly associate the "view_dashboard" action with the user who performed it, satisfying the table's integrity constraints.