### PR TITLE
Fix: Use correct 'completed_at' column in MiembroDashboardService

### DIFF
--- a/app/Domain/Dashboard/Services/MiembroDashboardService.php
+++ b/app/Domain/Dashboard/Services/MiembroDashboardService.php
@@ -44,8 +44,8 @@ class MiembroDashboardService
 
         return Task::where('assigned_to', $user->id)
             ->whereIn('status', ['Completada', 'Cerrada']) // Assuming these are terminal statuses
-            ->whereNotNull('resolved_at') // Ensure resolved_at is not null
-            ->where('resolved_at', '>=', $thirtyDaysAgo)
+            ->whereNotNull('completed_at') // Ensure completed_at is not null
+            ->where('completed_at', '>=', $thirtyDaysAgo)
             ->count();
     }
 
@@ -57,7 +57,7 @@ class MiembroDashboardService
 
         $resolvedTasksWithDueDate = Task::where('assigned_to', $user->id)
             ->whereIn('status', ['Completada', 'Cerrada'])
-            ->whereNotNull('resolved_at')
+            ->whereNotNull('completed_at')
             ->whereNotNull('due_date')
             ->get();
 
@@ -67,9 +67,9 @@ class MiembroDashboardService
 
         $resolvedOnTimeCount = 0;
         foreach ($resolvedTasksWithDueDate as $task) {
-            $resolvedAtDate = Carbon::parse($task->resolved_at)->startOfDay();
+            $completedAtDate = Carbon::parse($task->completed_at)->startOfDay();
             $dueDate = Carbon::parse($task->due_date)->startOfDay();
-            if ($resolvedAtDate->lte($dueDate)) {
+            if ($completedAtDate->lte($dueDate)) {
                 $resolvedOnTimeCount++;
             }
         }


### PR DESCRIPTION
The MiembroDashboardService was attempting to query a 'resolved_at' column on the 'tasks' table for calculating member productivity and resolution time compliance. The correct column name for task completion in the 'tasks' table is 'completed_at'.

This commit updates `app/Domain/Dashboard/Services/MiembroDashboardService.php`:
- In `calculateIndividualProductivityLastMonth`, references to `resolved_at` in the Task query have been changed to `completed_at`.
- In `calculateResolutionTimeCompliance`, references to `resolved_at` in the Task query and in date parsing have been changed to `completed_at`. The local variable `$resolvedAtDate` was also renamed to `$completedAtDate` for clarity.

This change resolves the 'SQLSTATE[42S22]: Column not found' error and ensures dashboard metrics for members are calculated correctly using the appropriate database schema for tasks.