### PR TITLE
Fix: Resolve ambiguous 'id' column in LiderDashboardService

### DIFF
--- a/app/Domain/Dashboard/Services/LiderDashboardService.php
+++ b/app/Domain/Dashboard/Services/LiderDashboardService.php
@@ -14,9 +14,9 @@ class LiderDashboardService
     {
         $projectIds = [];
         if (method_exists($user, 'projectsLed')) {
-            $projectIds = $user->projectsLed()->pluck('id')->toArray();
+            $projectIds = $user->projectsLed()->pluck('projects.id')->toArray();
         } elseif (method_exists($user, 'projects')) {
-            $projectIds = $user->projects()->pluck('id')->toArray();
+            $projectIds = $user->projects()->pluck('projects.id')->toArray();
         }
 
         $projectsLedCount = count($projectIds);


### PR DESCRIPTION
The LiderDashboardService was using `pluck('id')` when fetching project IDs through the `projectsLed` or `projects` relationships on the User model. These relationships involve a join with a pivot table (e.g., `project_user`), and if both the `projects` table and the pivot table have an 'id' column, this leads to an 'SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in field list is ambiguous' error.

This commit updates `app/Domain/Dashboard/Services/LiderDashboardService.php`:
- Changed `$user->projectsLed()->pluck('id')` to `$user->projectsLed()->pluck('projects.id')`.
- Changed `$user->projects()->pluck('id')` to `$user->projects()->pluck('projects.id')`.

This explicitly selects the `id` column from the `projects` table, resolving the ambiguity and ensuring correct project ID retrieval.