### PR TITLE
Fix: More robust ID plucking in LiderDashboardService

### DIFF
--- a/app/Domain/Dashboard/Services/LiderDashboardService.php
+++ b/app/Domain/Dashboard/Services/LiderDashboardService.php
@@ -14,9 +14,9 @@ class LiderDashboardService
     {
         $projectIds = [];
         if (method_exists($user, 'projectsLed')) {
-            $projectIds = $user->projectsLed()->pluck('projects.id')->toArray();
+            $projectIds = $user->projectsLed()->select('projects.id')->pluck('projects.id')->toArray();
         } elseif (method_exists($user, 'projects')) {
-            $projectIds = $user->projects()->pluck('projects.id')->toArray();
+            $projectIds = $user->projects()->select('projects.id')->pluck('projects.id')->toArray();
         }
 
         $projectsLedCount = count($projectIds);


### PR DESCRIPTION
This commit further refines the fix for the 'ambiguous column id' error you encountered in LiderDashboardService when fetching project IDs. The previous fix changed `pluck('id')` to `pluck('projects.id')`. However, if the underlying relationship method (e.g., `projectsLed`) itself contains an ambiguous `select()` clause, `pluck('projects.id')` alone might not resolve the issue if the generated SQL still defaults to an unqualified `select id`.

This commit updates `app/Domain/Dashboard/Services/LiderDashboardService.php` by adding an explicit `select('projects.id')` call *before* the `pluck('projects.id')` call:

- `$user->projectsLed()->pluck('projects.id')` is now `$user->projectsLed()->select('projects.id')->pluck('projects.id')`.
- `$user->projects()->pluck('projects.id')` is now `$user->projects()->select('projects.id')->pluck('projects.id')`.

This ensures that the SELECT clause of the query is explicitly and unambiguously set to `projects.id` immediately before plucking, overriding any potentially conflicting select statements from the relationship definition and preventing the ambiguous column error.